### PR TITLE
[fix] Docker 컨테이너 로그 디렉토리 볼륨 마운트 추가 및 배포 프로세스 완전 자동화

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -33,13 +33,14 @@ CMDS=(
   "docker stop ${CONTAINER_NAME} || true"
   "docker rm   ${CONTAINER_NAME} || true"
   "docker run -d \\
-      --name ${CONTAINER_NAME} \\
-      --restart=always \\
-      -p ${APP_PORT}:${APP_PORT} \\
-      -e SPRING_PROFILES_ACTIVE=${SPRING_PROFILE} \\
-      -e AWS_REGION=${AWS_REGION} \\
-      ${FULL_URI}"
-  )
+    --name ${CONTAINER_NAME} \\
+    --restart=always \\
+    -p ${APP_PORT}:${APP_PORT} \\
+    -v /app-logs:/app-logs \\
+    -e SPRING_PROFILES_ACTIVE=${SPRING_PROFILE} \\
+    -e AWS_REGION=${AWS_REGION} \\
+    ${FULL_URI}"
+)
 
 # Bash 배열 → JSON 배열 변환 (jq 필수)
 COMMANDS_JSON=$(jq -Rn --argjson arr "$(printf '%s\n' "${CMDS[@]}" | jq -R . | jq -s .)" '$arr')

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,10 @@ CMDS=(
   "docker pull ${FULL_URI}"
   "docker stop ${CONTAINER_NAME} || true"
   "docker rm   ${CONTAINER_NAME} || true"
+
+  # 로그 디렉토리 생성 및 spring 유저(999:999)에게 권한
+  "mkdir -p /app-logs && chown 999:999 /app-logs"
+
   "docker run -d \\
     --name ${CONTAINER_NAME} \\
     --restart=always \\


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #13

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 호스트(EC2)의 /app-logs 디렉토리를 컨테이너의 /app-logs에 마운트(전제: EC2에 디렉토리 생성)
- 컨테이너 재시작 시에도 로그 파일 영구 보관 가능
- 호스트에서 직접 로그 확인 가능
- 배포 프로세스 완전 자동화

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
