### PR TITLE
[fix] SecurityContext 재사용으로 인한 사용자 인증 정보 혼선 버그 수정

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/ootoutfitoftoday/security/filter/JwtAuthenticationFilter.java
@@ -140,9 +140,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             Claims claims = jwtUtil.extractClaims(jwt);
 
-            if (SecurityContextHolder.getContext().getAuthentication() == null) {
-                setAuthentication(claims);
-            }
+            // 로그 추가(디버깅용)
+            log.info("JWT 토큰 파싱 완료 - userId: {}, URI: {}", claims.getSubject(), request.getRequestURI());
+
+            // 항상 새로운 Authentication 설정
+            setAuthentication(claims);
 
             return true;
 

--- a/src/main/java/org/example/ootoutfitoftoday/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/ootoutfitoftoday/security/filter/JwtAuthenticationFilter.java
@@ -141,7 +141,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Claims claims = jwtUtil.extractClaims(jwt);
 
             // 로그 추가(디버깅용)
-            log.info("JWT 토큰 파싱 완료 - userId: {}, URI: {}", claims.getSubject(), request.getRequestURI());
+            log.debug("JWT 토큰 파싱 완료 - userId: {}, URI: {}", claims.getSubject(), request.getRequestURI());
 
             // 항상 새로운 Authentication 설정
             setAuthentication(claims);


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #27

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

로컬, 개발 서버에서 토큰 문제: 사용자 A의 토큰으로 요청 시 사용자 B의 정보가 반환되는 심각한 보안 버그 발생
JwtAuthenticationFilter에서 아래의 인증 객체(Authentication) 존재 여부 조건문 확인

```
if (SecurityContextHolder.getContext().getAuthentication() == null) {
    setAuthentication(claims);
}
```

SecurityContext에 인증 정보 존재 시, 새 JWT를 파싱해도 Authentication를 갱신하지 않고 재사용하는 위 조건문을 제거하여

- 항상 새로운 Authentication 생성
- ThreadLocal 오염으로 인한 사용자 정보 혼선 문제 해결
- JWT Stateless 원칙에 맞게 상태 재사용 방지

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
