### PR TITLE
[ci] Redis를 전용 EC2 인스턴스로 분리 및 배포 파이프라인 구축 

### DIFF
--- a/.github/workflows/dev-deploy-redis.yml
+++ b/.github/workflows/dev-deploy-redis.yml
@@ -1,0 +1,82 @@
+name: Deploy Redis (dev)
+
+on:
+  workflow_dispatch:    # 수동 실행만
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
+  REDIS_ECR_REPO: ${{ secrets.REDIS_ECR_REPO }}                  # Redis 전용 레포
+  IMAGE_TAG: 7-alpine                                            # Redis 버전
+  REDIS_EC2_INSTANCE_ID: ${{ secrets.REDIS_EC2_INSTANCE_ID }}    # Redis EC2
+  CONTAINER_NAME: redis
+  REDIS_PORT: "6379"
+  SPRING_PROFILE: dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-redis-dev
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: chmod +x scripts/*.sh
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/github-oidc-role
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build & Push Redis to ECR
+        id: push
+        run: |
+          ./scripts/ecr-push-redis.sh    # Redis 전용 스크립트
+        # ecr-push-redis.sh가 FULL_URI를 $GITHUB_OUTPUT에 기록
+
+      - name: Deploy Redis on EC2 via SSM
+        env:
+          FULL_URI: ${{ steps.push.outputs.FULL_URI }}
+        run: |
+          ./scripts/deploy-redis.sh    # Redis 전용 스크립트
+
+      # 추가: Deploy 실패 시 SSM 상세 로그 출력
+      - name: Get SSM command details on failure
+        if: failure()
+        run: |
+          echo "Fetching last SSM command details..."
+          LAST_COMMAND_ID=$(aws ssm list-commands \
+            --instance-id ${REDIS_EC2_INSTANCE_ID} \
+            --max-results 1 \
+            --region ${AWS_REGION} \
+            --query 'Commands[0].CommandId' \
+            --output text)
+          
+          echo "Command ID: $LAST_COMMAND_ID"
+          
+          aws ssm get-command-invocation \
+            --command-id "$LAST_COMMAND_ID" \
+            --instance-id ${REDIS_EC2_INSTANCE_ID} \
+            --region ${AWS_REGION} \
+            --query '{Status:Status,StatusDetails:StatusDetails,StandardOutput:StandardOutputContent,StandardError:StandardErrorContent}' \
+            --output json
+
+      - name: Verify Redis container
+        run: |
+          aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --targets "Key=instanceIds,Values=${REDIS_INSTANCE_ID}" \
+            --parameters commands="[
+              \"docker ps --format 'table {{.Names}}\\t{{.Image}}\\t{{.Status}}'\",
+              \"docker exec redis redis-cli -a \$(aws ssm get-parameter --name /config/dev/REDIS_PASSWORD --with-decryption --query Parameter.Value --output text --region ap-northeast-2) ping\"
+            ]" \
+            --region $AWS_REGION --output json

--- a/scripts/deploy-redis.sh
+++ b/scripts/deploy-redis.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ===== 필수 환경변수 점검 =====
+: "${AWS_REGION:?AWS_REGION required}"
+: "${REDIS_EC2_INSTANCE_ID:?REDIS_EC2_INSTANCE_ID required}"
+: "${FULL_URI:?FULL_URI required}"
+: "${CONTAINER_NAME:?CONTAINER_NAME required}"
+: "${REDIS_PORT:?REDIS_PORT required}"
+: "${SPRING_PROFILE:?SPRING_PROFILE required}"
+
+# ===== ECR 경로 파싱 =====
+REG_URI="$(echo "${FULL_URI}" | cut -d/ -f1)"
+REPO_AND_TAG="$(echo "${FULL_URI}" | cut -d/ -f2- )"
+REPO="$(echo "${REPO_AND_TAG}" | rev | cut -d: -f2- | rev)"
+TAG="$(echo "${REPO_AND_TAG}"  | awk -F: '{print $NF}')"
+
+# SSM 코멘트(100자 제한 방어)
+COMMENT="Deploy Redis ${REPO}:${TAG}"
+if [ ${#COMMENT} -gt 100 ]; then
+  COMMENT="${COMMENT:0:100}"
+fi
+
+echo "[INFO] FULL_URI=${FULL_URI}"
+echo "[INFO] REG_URI=${REG_URI}"
+echo "[INFO] REDIS_EC2_INSTANCE_ID=${REDIS_EC2_INSTANCE_ID}"
+echo "[INFO] COMMENT=${COMMENT}"
+
+# ===== EC2에서 실행할 커맨드(배열로 안전하게 정의) =====
+CMDS=(
+  # ECR 로그인
+  "aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${REG_URI}"
+
+  # Redis 이미지 Pull
+  "docker pull ${FULL_URI}"
+
+  # 기존 Redis 컨테이너 중지/삭제
+  "docker stop ${CONTAINER_NAME} || true"
+  "docker rm   ${CONTAINER_NAME} || true"
+
+  # Parameter Store에서 Redis 비밀번호 가져오기
+  "REDIS_PASSWORD=\$(aws ssm get-parameter \\
+    --name /config/${SPRING_PROFILE}/REDIS_PASSWORD \\
+    --with-decryption \\
+    --query Parameter.Value \\
+    --output text \\
+    --region ${AWS_REGION}) || { echo 'Error: Failed to retrieve REDIS_PASSWORD' >&2; exit 1; }"
+
+  # Redis 비밀번호 검증
+  "[ -n \"\$REDIS_PASSWORD\" ] || { echo 'Error: REDIS_PASSWORD is empty' >&2; exit 1; }"
+
+  # Redis 컨테이너 실행
+  "docker run -d \\
+    --name ${CONTAINER_NAME} \\
+    --restart=always \\
+    -p ${REDIS_PORT}:${REDIS_PORT} \\
+    -v redis-data:/data \\
+    ${FULL_URI} \\
+    redis-server \\
+      --requirepass \"\$REDIS_PASSWORD\" \\
+      --maxmemory 512mb \\
+      --maxmemory-policy allkeys-lru \\
+      --appendonly yes"
+
+  # 컨테이너 상태 확인
+  "sleep 3"
+  "docker ps | grep ${CONTAINER_NAME}"
+
+  # Redis 연결 테스트
+  "docker exec ${CONTAINER_NAME} redis-cli -a \"\$REDIS_PASSWORD\" ping || echo 'Redis health check failed'"
+)
+
+# Bash 배열 → JSON 배열 변환(jq 필수)
+COMMANDS_JSON=$(jq -Rn --argjson arr "$(printf '%s\n' "${CMDS[@]}" | jq -R . | jq -s .)" '$arr')
+echo "[DEBUG] COMMANDS_JSON=${COMMANDS_JSON}"
+
+# ===== SSM 명령 전송 =====
+RESP=$(aws ssm send-command \
+  --document-name "AWS-RunShellScript" \
+  --comment "${COMMENT}" \
+  --targets "Key=instanceIds,Values=${REDIS_EC2_INSTANCE_ID}" \
+  --parameters "{\"commands\": ${COMMANDS_JSON}}" \
+  --region "${AWS_REGION}" \
+  --output json)
+
+CMD_ID=$(echo "${RESP}" | jq -r '.Command.CommandId')
+echo "[INFO] SSM CommandId: ${CMD_ID}"
+
+# ===== 완료 대기/성공 판정 =====
+for i in {1..30}; do
+  STATUS=$(aws ssm get-command-invocation \
+    --command-id "${CMD_ID}" \
+    --instance-id "${REDIS_EC2_INSTANCE_ID}" \
+    --query 'Status' \
+    --output text \
+    --region "${AWS_REGION}") || true
+
+  echo "[INFO] SSM Status: ${STATUS}"
+
+  case "${STATUS}" in
+    Success) exit 0 ;;
+    Failed|Cancelled|TimedOut) echo "[ERROR] SSM failed: ${STATUS}"; exit 1 ;;
+  esac
+
+  sleep 5
+done
+
+echo "[ERROR] SSM command did not complete in time"
+exit 1

--- a/scripts/deploy-redis.sh
+++ b/scripts/deploy-redis.sh
@@ -67,7 +67,8 @@ CMDS=(
   "docker ps | grep ${CONTAINER_NAME}"
 
   # Redis 연결 테스트
-  "docker exec ${CONTAINER_NAME} redis-cli -a \"\$REDIS_PASSWORD\" ping || echo 'Redis health check failed'"
+  # 수정된 코드
+  "docker exec ${CONTAINER_NAME} redis-cli -a \"\$REDIS_PASSWORD\" ping || { echo 'Error: Redis health check failed' >&2; exit 1; }"
 )
 
 # Bash 배열 → JSON 배열 변환(jq 필수)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -36,40 +36,43 @@ CMDS=(
   # 로그 디렉토리 생성 및 spring 유저(999:999)에게 권한
   "mkdir -p /app-logs && chown 999:999 /app-logs"
 
-  # Docker 네트워크 생성(컨테이너 간 통신용)
-  # 이미 존재하면 에러 무시(|| true)
-  "docker network create oot-network || true"
+  # Parameter Store에서 Redis 설정 가져오기
+  "REDIS_HOST=\$(aws ssm get-parameter \\
+    --name /config/${SPRING_PROFILE}/REDIS_HOST \\
+    --query Parameter.Value \\
+    --output text \\
+    --region ${AWS_REGION}) || { echo 'Error: Failed to retrieve REDIS_HOST' >&2; exit 1; }"
 
-  # Parameter Store에서 Redis 비밀번호 가져오기(환경별 동적 경로) - 실패 시 즉시 중단
+  # ⭐ REDIS_PORT 추가
+  "REDIS_PORT=\$(aws ssm get-parameter \\
+    --name /config/${SPRING_PROFILE}/REDIS_PORT \\
+    --query Parameter.Value \\
+    --output text \\
+    --region ${AWS_REGION}) || { echo 'Error: Failed to retrieve REDIS_PORT' >&2; exit 1; }"
+
   "REDIS_PASSWORD=\$(aws ssm get-parameter \\
     --name /config/${SPRING_PROFILE}/REDIS_PASSWORD \\
     --with-decryption \\
     --query Parameter.Value \\
     --output text \\
-    --region ${AWS_REGION}) || { echo 'Error: Failed to retrieve REDIS_PASSWORD from Parameter Store' >&2; exit 1; }"
+    --region ${AWS_REGION}) || { echo 'Error: Failed to retrieve REDIS_PASSWORD' >&2; exit 1; }"
 
-  # Redis 비밀번호 값이 비어있는지 검증
+  # 값이 비어있는지 검증
+  "[ -n \"\$REDIS_HOST\" ] || { echo 'Error: REDIS_HOST is empty' >&2; exit 1; }"
+  "[ -n \"\$REDIS_PORT\" ] || { echo 'Error: REDIS_PORT is empty' >&2; exit 1; }"
   "[ -n \"\$REDIS_PASSWORD\" ] || { echo 'Error: REDIS_PASSWORD is empty' >&2; exit 1; }"
 
-  # Redis 컨테이너 실행
-  # 중지된 컨테이너가 있으면 시작, 없으면 새로 생성
-  # 컨테이너 이름: redis(Spring에서 호스트명으로 사용)
-  "docker start redis 2>/dev/null || docker run -d \\
-    --name redis \\
-    --network oot-network \\
-    --restart=always \\
-    redis:7-alpine redis-server --requirepass \$REDIS_PASSWORD --maxmemory 256mb --maxmemory-policy allkeys-lru"
-
-  # Spring Boot 애플리케이션 실행
-  # oot-network에 연결하여 Redis 컨테이너('redis')와 통신 가능
+  # Spring Boot 실행
   "docker run -d \\
     --name ${CONTAINER_NAME} \\
-    --network oot-network \\
     --restart=always \\
     -p ${APP_PORT}:${APP_PORT} \\
     -v /app-logs:/app-logs \\
     -e SPRING_PROFILES_ACTIVE=${SPRING_PROFILE} \\
     -e AWS_REGION=${AWS_REGION} \\
+    -e REDIS_HOST=\${REDIS_HOST} \\
+    -e REDIS_PORT=\${REDIS_PORT} \\
+    -e REDIS_PASSWORD=\${REDIS_PASSWORD} \\
     ${FULL_URI}"
 )
 

--- a/scripts/ecr-push-redis.sh
+++ b/scripts/ecr-push-redis.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 필수 env: AWS_REGION, ACCOUNT_ID, REDIS_ECR_REPO, IMAGE_TAG
+: "${AWS_REGION:?AWS_REGION required}"
+: "${ACCOUNT_ID:?ACCOUNT_ID required}"
+: "${REDIS_ECR_REPO:?REDIS_ECR_REPO required}"
+: "${IMAGE_TAG:?IMAGE_TAG required}"
+
+REG_URI="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+FULL_URI="${REG_URI}/${REDIS_ECR_REPO}:${IMAGE_TAG}"
+
+echo "[ECR] Login to ${REG_URI}"
+aws ecr get-login-password --region "${AWS_REGION}" \
+  | docker login --username AWS --password-stdin "${REG_URI}"
+
+# Redis 이미지 Pull(빌드 아님)
+echo "[ECR] Pull Redis image"
+docker pull redis:${IMAGE_TAG}
+
+# ECR에 태그
+echo "[ECR] Tag -> ${FULL_URI}"
+docker tag redis:${IMAGE_TAG} "${FULL_URI}"
+
+echo "[ECR] Push -> ${FULL_URI}"
+docker push "${FULL_URI}"
+
+# GitHub Actions 간 스텝 전달용
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "FULL_URI=${FULL_URI}" >> "${GITHUB_OUTPUT}"
+else
+  echo "FULL_URI=${FULL_URI}"
+fi


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #36

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 문제: 현재 메인 EC2 (t3.micro) 메모리 부족으로 배포 실패
- 원인: 퍼블릭 서브넷 A의 메인 EC2 인스턴스 내에 Java 애플리케이션과 Redis 동시 실행으로 리소스 경쟁 
- 해결: aws에서 퍼블릭 서브넷 A에 Redis 전용 EC2 인스턴스로 분리
-> 독립적인 배포 파이프라인을 구축하여 Redis 분리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
