### PR TITLE
[feat] SecurityContext 명시적 정리로 ThreadLocal 오염 방지 강화

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/ootoutfitoftoday/security/filter/JwtAuthenticationFilter.java
@@ -107,22 +107,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         log.info("JwtAuthenticationFilter 진입: {} {}", httpRequest.getMethod(), httpRequest.getRequestURI());
 
-        String authorizationHeader = httpRequest.getHeader("Authorization");
+        // try-finally 블록으로 감싸서 SecurityContext 정리 보장
+        try {
+            String authorizationHeader = httpRequest.getHeader("Authorization");
 
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            sendErrorResponse(httpResponse, HttpStatus.UNAUTHORIZED, "인증 토큰이 필요합니다.");
+            if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+                sendErrorResponse(httpResponse, HttpStatus.UNAUTHORIZED, "인증 토큰이 필요합니다.");
 
-            return;
+                return;
+            }
+
+            String jwt = jwtUtil.substringToken(authorizationHeader);
+
+            if (!processAuthentication(jwt, httpRequest, httpResponse)) {
+
+                return;
+            }
+
+            chain.doFilter(httpRequest, httpResponse);
+
+        } finally {
+            // 이중 안전장치: 요청 처리 완료 후 반드시 SecurityContext 정리
+            // Spring Security가 자동으로 clear하지만, ThreadLocal 오염 방지를 위해 명시적으로 정리
+            // 예외 발생 시에도 반드시 실행되어 Thread 재사용 시 이전 인증 정보가 남지 않도록 보장
+            SecurityContextHolder.clearContext();
+            log.debug("SecurityContext 명시적 정리 완료");
         }
-
-        String jwt = jwtUtil.substringToken(authorizationHeader);
-
-        if (!processAuthentication(jwt, httpRequest, httpResponse)) {
-
-            return;
-        }
-
-        chain.doFilter(httpRequest, httpResponse);
     }
 
     private boolean processAuthentication(


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #31

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- `doFilterInternal`에 `try-finally` 블록 추가
- 요청 처리 완료 후 `SecurityContextHolder.clearContext()` 명시적 호출
- 예외 발생 시에도 반드시 SecurityContext 정리되도록 보장
- Spring Security 자동 clear 실패 시 대비 이중 안전장치 구축

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
