### PR TITLE
[fix] SSM 배포 실패 시 상세 로그 출력 기능 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -237,8 +237,8 @@ for i in {1..30}; do
       fi
 
       # JSON 파싱 시도
-      if [ -z "$SSM_RESULT" ] || ! echo "${SSM_RESULT}" | jq -e . >/dev/null 2>&1; then
-        echo "Unable to parse logs from SSM"
+      if ! echo "${SSM_RESULT}" | jq -e . >/dev/null 2>&1; then
+        echo "Unable to parse SSM response"
         echo "Raw response:"
         echo "${SSM_RESULT}"
         exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -228,12 +228,11 @@ for i in {1..30}; do
 
       # AWS CLI 명령 자체의 성공/실패 확인
       if [ $? -ne 0 ]; then
-        echo "Failed to fetch logs from SSM(command may have expired or been deleted)"
+        echo "Failed to fetch detailed logs from EC2 instance"
+        echo "This can occur when the command has expired or been deleted"
+        echo ""
         echo "AWS CLI Error:"
         echo "${SSM_RESULT}"
-        echo ""
-        echo "This is likely because the command execution happened too long ago."
-        echo "For current failures, logs will be displayed above."
         exit 1
       fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -107,7 +107,7 @@ CMDS=(
   "for i in {1..30}; do
     CONTAINER_STATUS=\$(docker inspect -f '{{.State.Status}}' ${CONTAINER_NAME} 2>/dev/null || echo 'not_found')
     if [ \"\$CONTAINER_STATUS\" = \"running\" ]; then
-      echo \"✓ Container is running (attempt \$i/30)\"
+      echo \"✓ Container is running(attempt \$i/30)\"
       break
     fi
     if [ \$i -eq 30 ]; then
@@ -119,13 +119,13 @@ CMDS=(
       echo '' >&2
       docker ps -a --filter name=${CONTAINER_NAME} >&2 || true
       echo '' >&2
-      echo 'Container Logs (last 50 lines):' >&2
+      echo 'Container Logs(last 50 lines):' >&2
       docker logs ${CONTAINER_NAME} --tail 50 >&2 || true
       echo '' >&2
       echo '========================================' >&2
       exit 1
     fi
-    echo \"Waiting for container... (attempt \$i/30, status: \$CONTAINER_STATUS)\"
+    echo \"Waiting for container...(attempt \$i/30, status: \$CONTAINER_STATUS)\"
     sleep 1
   done"
 
@@ -135,7 +135,7 @@ CMDS=(
   "for i in {1..60}; do
     HEALTH_STATUS=\$(curl -f -s http://localhost:${APP_PORT}/api/actuator/health 2>/dev/null | grep -o '\"status\":\"UP\"' || echo '')
     if [ -n \"\$HEALTH_STATUS\" ]; then
-      echo \"✓ Application is healthy (attempt \$i/60)\"
+      echo \"✓ Application is healthy(attempt \$i/60)\"
       echo \"Health response: \$(curl -s http://localhost:${APP_PORT}/api/actuator/health 2>/dev/null)\"
       break
     fi
@@ -150,13 +150,13 @@ CMDS=(
       echo 'Container Status:' >&2
       docker ps --filter name=${CONTAINER_NAME} >&2
       echo '' >&2
-      echo 'Container Logs (last 50 lines):' >&2
+      echo 'Container Logs(last 50 lines):' >&2
       docker logs ${CONTAINER_NAME} --tail 50 >&2
       echo '' >&2
       echo '========================================' >&2
       exit 1
     fi
-    echo \"Waiting for application health... (attempt \$i/60)\"
+    echo \"Waiting for application health...(attempt \$i/60)\"
     sleep 1
   done"
 
@@ -215,19 +215,33 @@ for i in {1..30}; do
       echo "  SSM Command Failed: ${STATUS}"
       echo "========================================"
       echo ""
-      echo "Fetching error logs from EC2..."
+      echo "Attempting to fetch error logs from EC2..."
       echo ""
 
-      # 실패 원인 파악을 위한 로그 출력
+      # 실패 원인 파악을 위한 로그 출력(에러도 캡처)
       SSM_RESULT=$(aws ssm get-command-invocation \
         --command-id "${CMD_ID}" \
         --instance-id "${EC2_INSTANCE_ID}" \
         --query '{stdOut: StandardOutputContent, stdErr: StandardErrorContent}' \
         --output json \
-        --region "${AWS_REGION}" 2>/dev/null)
+        --region "${AWS_REGION}" 2>&1)
 
-      if [ $? -ne 0 ] || [ -z "$SSM_RESULT" ]; then
-        echo "Unable to fetch logs from SSM"
+      # AWS CLI 명령 자체의 성공/실패 확인
+      if [ $? -ne 0 ]; then
+        echo "Failed to fetch logs from SSM(command may have expired or been deleted)"
+        echo "AWS CLI Error:"
+        echo "${SSM_RESULT}"
+        echo ""
+        echo "This is likely because the command execution happened too long ago."
+        echo "For current failures, logs will be displayed above."
+        exit 1
+      fi
+
+      # JSON 파싱 시도
+      if [ -z "$SSM_RESULT" ] || ! echo "${SSM_RESULT}" | jq -e . >/dev/null 2>&1; then
+        echo "Unable to parse logs from SSM"
+        echo "Raw response:"
+        echo "${SSM_RESULT}"
         exit 1
       fi
 


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #54

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- SSM 명령 실패 시 StandardOutput/StandardError 로그를 GitHub Actions에 출력하도록 개선
- AWS CLI 에러 메시지 캡처를 위해 stderr 리다이렉션 수정(`2>/dev/null` -> `2>&1`)
- 과거 명령 만료 시 명확한 안내 메시지 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
