### PR TITLE
[fix] Response 객체의 null 필드가 JSON 응답에 포함되는 문제 해결

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/common/config/RedisConfig.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/config/RedisConfig.java
@@ -14,7 +14,6 @@ import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCust
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
@@ -43,14 +42,15 @@ public class RedisConfig {
      * - JavaTimeModule: LocalDateTime 등 Java 8 시간 타입 지원
      * - WRITE_DATES_AS_TIMESTAMPS 비활성화: ISO-8601 문자열 형식으로 날짜 직렬화
      */
-    @Bean
-    @Primary
-    public ObjectMapper globalObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        return mapper;
-    }
+//    @Bean
+//    // @Primary
+//    // globalObjectMapper()
+//    public ObjectMapper cacheObjectMapper() {
+//        ObjectMapper mapper = new ObjectMapper();
+//        mapper.registerModule(new JavaTimeModule());
+//        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+//        return mapper;
+//    }
 
     /**
      * Redis용 ObjectMapper(타입 정보 포함)

--- a/src/main/java/org/example/ootoutfitoftoday/common/response/Response.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/response/Response.java
@@ -9,12 +9,14 @@ import org.springframework.http.ResponseEntity;
 import java.time.LocalDateTime;
 
 @Builder
+//@JsonInclude(JsonInclude.Include.NON_NULL)
 public record Response<T>(
         HttpStatus httpStatus,
         int statusValue,
         boolean success,
         String code,
         String message,
+        //@JsonInclude(JsonInclude.Include.NON_NULL)
         T data,
         LocalDateTime timestamp
 ) {

--- a/src/main/java/org/example/ootoutfitoftoday/domain/user/dto/response/UserGetMyInfoResponse.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/user/dto/response/UserGetMyInfoResponse.java
@@ -1,6 +1,5 @@
 package org.example.ootoutfitoftoday.domain.user.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +11,6 @@ import org.example.ootoutfitoftoday.domain.user.entity.User;
 
 import java.math.BigDecimal;
 
-@JsonInclude(JsonInclude.Include.ALWAYS)
 @Getter
 @Builder
 @RequiredArgsConstructor


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #67

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

application.yml에 Jackson의 default-property-inclusion: non_null 설정이 존재함에도 불구
-> 공통 응답 객체(Response)의 null 필드가 JSON 응답에 그대로 노출되는 문제
=> 근본 원인을 찾아 해결(단, 현재 삭제가 아닌 주석 처리)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
