### PR TITLE
[refactor] Redisson 설정 Duration 타입으로 통일 및 Redis 타임아웃 전략 개선

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/common/config/RedissonConfig.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/config/RedissonConfig.java
@@ -45,15 +45,16 @@ public class RedissonConfig {
                 // 커넥션 풀 설정
                 .setConnectionPoolSize(redisProperties.getLettuce().getPool().getMaxActive())
                 .setConnectionMinimumIdleSize(redisProperties.getLettuce().getPool().getMinIdle())
-                // Redisson 전용 설정
-                .setIdleConnectionTimeout((int) redissonProperties.getIdleConnectionTimeout().toMillis())
+                // Redisson 전용 설정(Duration -> int 안전 변환)
+                // Math.toIntExact(): 오버플로우 발생 시 ArithmeticException 발생
+                .setIdleConnectionTimeout(Math.toIntExact(redissonProperties.getIdleConnectionTimeout().toMillis()))
                 // 타임아웃 설정
-                .setConnectTimeout((int) redisProperties.getTimeout().toMillis())
-                .setTimeout((int) redisProperties.getTimeout().toMillis())
-                // 재시도 설정
+                .setConnectTimeout(Math.toIntExact(redisProperties.getTimeout().toMillis()))
+                .setTimeout(Math.toIntExact(redisProperties.getTimeout().toMillis()))
+                // 재시도 설정(Duration -> int 안전 변환)
                 .setRetryAttempts(redissonProperties.getRetryAttempts())
                 // deprecated 되었으나, 신규의 setRetryInterval(Duration) 사용 불가
-                .setRetryInterval((int) redissonProperties.getRetryInterval().toMillis());
+                .setRetryInterval(Math.toIntExact(redissonProperties.getRetryInterval().toMillis()));
 
         // 비밀번호 설정
         if (StringUtils.hasText(redisProperties.getPassword())) {

--- a/src/main/java/org/example/ootoutfitoftoday/common/config/RedissonConfig.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/config/RedissonConfig.java
@@ -46,14 +46,14 @@ public class RedissonConfig {
                 .setConnectionPoolSize(redisProperties.getLettuce().getPool().getMaxActive())
                 .setConnectionMinimumIdleSize(redisProperties.getLettuce().getPool().getMinIdle())
                 // Redisson 전용 설정
-                .setIdleConnectionTimeout(redissonProperties.getIdleConnectionTimeout())
+                .setIdleConnectionTimeout((int) redissonProperties.getIdleConnectionTimeout().toMillis())
                 // 타임아웃 설정
                 .setConnectTimeout((int) redisProperties.getTimeout().toMillis())
                 .setTimeout((int) redisProperties.getTimeout().toMillis())
                 // 재시도 설정
                 .setRetryAttempts(redissonProperties.getRetryAttempts())
                 // deprecated 되었으나, 신규의 setRetryInterval(Duration) 사용 불가
-                .setRetryInterval(redissonProperties.getRetryInterval());
+                .setRetryInterval((int) redissonProperties.getRetryInterval().toMillis());
 
         // 비밀번호 설정
         if (StringUtils.hasText(redisProperties.getPassword())) {

--- a/src/main/java/org/example/ootoutfitoftoday/common/config/RedissonProperties.java
+++ b/src/main/java/org/example/ootoutfitoftoday/common/config/RedissonProperties.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 /**
  * Redisson 설정 Properties
  * yaml의 redisson 하위 설정을 자동으로 바인딩
@@ -15,18 +17,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "redisson")
 public final class RedissonProperties {
 
-    // 유휴 연결 타임아웃 (밀리초)
+    // 유휴 연결 타임아웃(초)
     // 연결이 이 시간 동안 사용되지 않으면 종료
     // 기본값: 10초
-    private int idleConnectionTimeout = 10_000;
+    private Duration idleConnectionTimeout = Duration.ofSeconds(10);
 
     // 재시도 횟수
     // Redis 연결 실패 시 재시도 횟수
     // 기본값: 3회
     private int retryAttempts = 3;
 
-    // 재시도 간격 (밀리초)
+    // 재시도 간격(밀리초)
     // 각 재시도 사이의 대기 시간
     // 기본값: 1.5초
-    private int retryInterval = 1_500;
+    private Duration retryInterval = Duration.ofMillis(1500);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
       lettuce:
         pool:
           # 커넥션 획득 대기 타임아웃(-1ms: 무제한)
-          max-wait: -1ms
+          max-wait: 2s
 
   # ================================================================
   # Spring Cache 설정(Spring이 관리)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,11 +58,11 @@ spring:
       # JPA Repository 자동 생성 비활성화(수동 설정 사용)
       repositories:
         enabled: false
-      # Redis 연결 타임아웃
-      timeout: 3000ms
+      # Redis 명령 실행 타임아웃
+      timeout: 3s
       lettuce:
         pool:
-          # 연결 대기 시간(-1: 무제한)
+          # 커넥션 획득 대기 타임아웃(-1ms: 무제한)
           max-wait: -1ms
 
   # ================================================================
@@ -206,11 +206,11 @@ cache:
 # ================================================================
 redisson:
   # 유휴 연결 타임아웃(10초)
-  idle-connection-timeout: 10000
+  idle-connection-timeout: 10s
   # 재시도 횟수
   retry-attempts: 3
   # 재시도 간격(1.5초)
-  retry-interval: 1500
+  retry-interval: 1500ms
 
 # ================================================================
 # 서버 설정


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #58

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 목적
- Redisson 시간 설정을 Duration 타입으로 변경하여 가독성 및 일관성 향상
- Redis 커넥션 타임아웃 전략 개선으로 장애 격리 및 운영 안정성 확보

### 작업 내용
**1. RedissonProperties Duration 타입 변경**
- `int idleConnectionTimeout` -> `Duration idleConnectionTimeout`
- `int retryInterval `-> `Duration retryInterval`
=> 기본값을 Duration으로 변경

**2. RedissonConfig 수정**
- Duration을 밀리초로 변환하여 Redisson API에 전달
- `(int)` 강제 형변환 → `Math.toIntExact()` 사용
- 오버플로우 발생 시 `ArithmeticException`으로 조기 실패
  
- **오버플로우 방지 이유:**
  - 현재 설정값은 모두 int 범위 내이지만, 향후 잘못된 설정 입력을 방지하기 위한 방어 코드 추가
  - Duration.toMillis()를 int로 강제 형변환 시 오버플로우 위험
    - 잘못된 설정값(예: `Duration.ofDays(30)`) 입력 시, int 범위 초과로 음수 변환되어 오작동 가능
  - 오버플로우 발생 시 ArithmeticException 발생
  - 애플리케이션 시작 시점에 문제 조기 발견 가능

**3. application.yml Duration 표기 통일**
- `idle-connection-timeout: 10000` → `10s`
- `retry-interval: 1500` → `1500ms`
- `timeout: 3000ms` → `3s`

**4. Redis 타임아웃 전략 개선**
- **변경 전:** `max-wait: -1ms`(무제한 대기)
- **문제점:**
  1. Redis가 느려짐
  2. 커넥션 풀 고갈(max-active: 10개 모두 사용 중)
  3. 신규 요청들이 무한 대기
  4. Tomcat 스레드 200개가 모두 대기 상태
  5. 서비스 전체 멈춤

- **변경 후:** `max-wait: 2s`(2초 제한)
- **개선 효과:**
  1. Redis가 느려짐
  2. 커넥션 풀 고갈
  3. 신규 요청이 최대 2초 대기
  4. 2초 후 예외 발생 -> 사용자에게 500 에러
  5. 스레드는 해제되어 다른 요청 처리 가능
  6. 서비스는 살아있음(Redis 문제만 에러)

- **max-wait: 2s 선택 이유**
  1. **정상 상황**: 커넥션 획득 < 10ms
  2. **문제 상황**: 2초 안에 커넥션 못 얻으면 이미 심각한 상태
  3. **사용자 경험**: 무한 대기보다 빠른 에러가 나음(Retry 가능)

- **타임아웃 계층:**
  - **1단계: 커넥션 획득** - 최대 2초 대기(max-wait: 2s)
  - **2단계: Redis 명령 실행** - 최대 3초 대기(timeout: 3s)
  - **총 최대 대기 시간: 5초**

### 기대 효과
**1. 가독성 향상:** 한눈에 단위 파악 가능

**2. 타입 안정성:** 
  - Duration 타입으로 시간값임을 명시
  - 컴파일 타임에 타입 검증

**3. 오버플로우 방지**
- `Math.toIntExact()` 사용으로 안전한 형변환
- 잘못된 설정값 입력 시 애플리케이션 시작 실패로 조기 발견

**4. 일관성:**
  - CacheTtlProperties도 Duration 사용
  - RedissonProperties도 동일한 패턴 적용
  - 프로젝트 전체 시간 설정 통일

**5. 장애 격리:**
  - Redis 장애 시, Redis만 에러, 서비스 정상 -> 전체 서비스 다운 방지
  - 스레드 고갈 방지
  - 빠른 실패(Fail Fast)로 운영 안정성 확보

**6. 운영 편의성:**
  - 모니터링 용이(2초 타임아웃 메트릭 수집)
  - 장애 원인 파악 용이(전체가 멈추는 것이 아니라 Redis만 에러이므로)
  - 예측 가능한 응답 시간

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
