### PR TITLE
[fix] Clothes 유스케이스 분리로 순환참조 제거

### DIFF
--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/controller/ClothesControllerImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/controller/ClothesControllerImpl.java
@@ -14,6 +14,7 @@ import org.example.ootoutfitoftoday.domain.clothes.dto.response.ClothesSummaryRe
 import org.example.ootoutfitoftoday.domain.clothes.exception.ClothesSuccessCode;
 import org.example.ootoutfitoftoday.domain.clothes.service.command.ClothesCommandService;
 import org.example.ootoutfitoftoday.domain.clothes.service.query.ClothesQueryService;
+import org.example.ootoutfitoftoday.domain.clothes.service.usecase.ClothesUseCaseService;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,6 +27,7 @@ public class ClothesControllerImpl implements ClothesController {
 
     private final ClothesCommandService clothesCommandService;
     private final ClothesQueryService clothesQueryService;
+    private final ClothesUseCaseService clothesUseCaseService;
 
     @Override
     @PostMapping
@@ -89,7 +91,7 @@ public class ClothesControllerImpl implements ClothesController {
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long clothesId
     ) {
-        clothesCommandService.deleteClothes(authUser.getUserId(), clothesId);
+        clothesUseCaseService.deleteClothes(authUser.getUserId(), clothesId);
 
         return Response.success(null, ClothesSuccessCode.CLOTHES_DELETE);
     }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandService.java
@@ -16,7 +16,7 @@ public interface ClothesCommandService {
             ClothesRequest clothesRequest
     );
 
-    void deleteClothes(Long userId, Long clothesId);
+    void softDeleteByUserIdAndClothesIdAndIsDeletedFalse(Long userId, Long clothesId);
 
     void clearCategoryFromClothes(List<Long> categoryIds);
 

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/command/ClothesCommandServiceImpl.java
@@ -10,10 +10,8 @@ import org.example.ootoutfitoftoday.domain.clothes.entity.Clothes;
 import org.example.ootoutfitoftoday.domain.clothes.exception.ClothesErrorCode;
 import org.example.ootoutfitoftoday.domain.clothes.exception.ClothesException;
 import org.example.ootoutfitoftoday.domain.clothes.repository.ClothesRepository;
-import org.example.ootoutfitoftoday.domain.clothesImage.service.command.ClothesImageCommandService;
 import org.example.ootoutfitoftoday.domain.user.entity.User;
 import org.example.ootoutfitoftoday.domain.user.service.query.UserQueryService;
-import org.example.ootoutfitoftoday.domain.wearrecord.service.command.WearRecordCommandService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +27,6 @@ public class ClothesCommandServiceImpl implements ClothesCommandService {
     private final ClothesRepository clothesRepository;
     private final CategoryQueryServiceImpl categoryQueryService;
     private final UserQueryService userQueryService;
-    private final ClothesImageCommandService clothesImageCommandService;
-    private final WearRecordCommandService wearRecordCommandService;
 
     @Override
     public ClothesResponse createClothes(Long userId, ClothesRequest clothesRequest) {
@@ -80,7 +76,7 @@ public class ClothesCommandServiceImpl implements ClothesCommandService {
     }
 
     @Override
-    public void deleteClothes(Long userId, Long clothesId) {
+    public void softDeleteByUserIdAndClothesIdAndIsDeletedFalse(Long userId, Long clothesId) {
         Clothes clothes = clothesRepository.findClothesByIdAndUserIdAndIsDeletedFalse(userId, clothesId).orElseThrow(
                 () -> {
                     log.warn("deleteClothes - 옷 없음. clothesId={}", clothesId);
@@ -88,10 +84,6 @@ public class ClothesCommandServiceImpl implements ClothesCommandService {
                 });
 
         clothes.softDelete();
-
-        wearRecordCommandService.softDeleteByUserIdAndClothesIdAndIsDeletedFalse(userId, clothesId);
-
-        clothesImageCommandService.softDeleteAllByClothesId(clothesId);
     }
 
     @Override

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/usecase/ClothesUseCaseService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothes/service/usecase/ClothesUseCaseService.java
@@ -1,0 +1,26 @@
+package org.example.ootoutfitoftoday.domain.clothes.service.usecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.ootoutfitoftoday.domain.clothes.service.command.ClothesCommandService;
+import org.example.ootoutfitoftoday.domain.clothesImage.service.command.ClothesImageCommandService;
+import org.example.ootoutfitoftoday.domain.wearrecord.service.command.WearRecordCommandService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClothesUseCaseService {
+
+    private final ClothesCommandService clothesCommandService;
+    private final WearRecordCommandService wearRecordCommandService;
+    private final ClothesImageCommandService clothesImageCommandService;
+
+    public void deleteClothes(Long userId, Long clothesId) {
+        clothesCommandService.softDeleteByUserIdAndClothesIdAndIsDeletedFalse(userId, clothesId); // 옷 삭제
+        wearRecordCommandService.softDeleteByUserIdAndClothesIdAndIsDeletedFalse(userId, clothesId); // 착용 기록 삭제
+        clothesImageCommandService.softDeleteAllByClothesIdIsDeletedFalse(clothesId); // 옷 이미지 삭제
+    }
+}

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/repository/ClothesImageRepository.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/repository/ClothesImageRepository.java
@@ -18,7 +18,7 @@ public interface ClothesImageRepository extends JpaRepository<ClothesImage, Long
             WHERE ci.clothes.id = :clothesId
               AND ci.isDeleted = false
             """)
-    int softDeleteAllByClothesId(@Param("clothesId") Long clothesId);
+    int softDeleteAllByClothesIdIsDeletedFalse(@Param("clothesId") Long clothesId);
 
     @Query("""
             SELECT EXISTS (

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandService.java
@@ -12,5 +12,5 @@ public interface ClothesImageCommandService {
 
     void removeClothesImages(Long userId, Long clothesId, ClothesImageRequest clothesImageRequest);
 
-    int softDeleteAllByClothesIdIsDeletedFalse(Long id);
+    int softDeleteAllByClothesIdIsDeletedFalse(Long clothesId);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandService.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandService.java
@@ -12,5 +12,5 @@ public interface ClothesImageCommandService {
 
     void removeClothesImages(Long userId, Long clothesId, ClothesImageRequest clothesImageRequest);
 
-    int softDeleteAllByClothesId(Long id);
+    int softDeleteAllByClothesIdIsDeletedFalse(Long id);
 }

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandServiceImpl.java
@@ -202,8 +202,9 @@ public class ClothesImageCommandServiceImpl implements ClothesImageCommandServic
     }
 
     @Override
-    public int softDeleteAllByClothesId(Long id) {
-        return clothesImageRepository.softDeleteAllByClothesId(id);
+    public int softDeleteAllByClothesIdIsDeletedFalse(Long id) {
+
+        return clothesImageRepository.softDeleteAllByClothesIdIsDeletedFalse(id);
     }
 
     /**

--- a/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandServiceImpl.java
+++ b/src/main/java/org/example/ootoutfitoftoday/domain/clothesImage/service/command/ClothesImageCommandServiceImpl.java
@@ -202,9 +202,9 @@ public class ClothesImageCommandServiceImpl implements ClothesImageCommandServic
     }
 
     @Override
-    public int softDeleteAllByClothesIdIsDeletedFalse(Long id) {
+    public int softDeleteAllByClothesIdIsDeletedFalse(Long clothesId) {
 
-        return clothesImageRepository.softDeleteAllByClothesIdIsDeletedFalse(id);
+        return clothesImageRepository.softDeleteAllByClothesIdIsDeletedFalse(clothesId);
     }
 
     /**


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 --> 

- Closes #83

## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
  - 원인: Clothes 삭제 시 WearRecord 정리, WearRecord 생성 시 Clothes 갱신 로직이 서로 서비스 주입을 만들어 순환참조 발생
  - 해결: 삭제 유스케이스를 상위 오케스트레이터로 분리하여 서비스 간 직접 참조 제거

  변경 사항

  - ClothesUseCaseService 추가: 옷 삭제 시 Clothes, WearRecord, Images를 한 트랜잭션에서 처리
  - ClothesControllerImpl이 삭제 요청을 유스케이스로 위임
  - ClothesCommandServiceImpl은 옷 soft delete만 수행
  - WearRecordCommandServiceImpl은 ClothesCommandService를 통해 lastWornAt 갱신(단방향 유지)
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
옷 삭제 api 호출 시 발생 쿼리
```
Hibernate: 
    select
        c1_0.id,
        c1_0.category_id,
        c1_0.clothes_color,
        c1_0.clothes_size,
        c1_0.created_at,
        c1_0.deleted_at,
        c1_0.description,
        c1_0.is_deleted,
        c1_0.last_worn_at,
        c1_0.updated_at,
        c1_0.user_id 
    from
        clothes c1_0 
    where
        c1_0.user_id=? 
        and c1_0.id=? 
        and c1_0.is_deleted=0
Hibernate: 
    update
        clothes 
    set
        category_id=?,
        clothes_color=?,
        clothes_size=?,
        deleted_at=?,
        description=?,
        is_deleted=?,
        last_worn_at=?,
        updated_at=?,
        user_id=? 
    where
        id=?
Hibernate: 
    update
        wear_records wr1_0 
    set
        is_deleted=1,
        deleted_at=current_timestamp(6) 
    where
        wr1_0.user_id=? 
        and wr1_0.clothes_id=? 
        and wr1_0.is_deleted=0
Hibernate: 
    update
        clothes_images ci1_0 
    set
        is_deleted=1,
        deleted_at=current_timestamp(6) 
    where
        ci1_0.clothes_id=? 
        and ci1_0.is_deleted=0
```
## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
